### PR TITLE
User story 2

### DIFF
--- a/app/controllers/applications_controller.rb
+++ b/app/controllers/applications_controller.rb
@@ -2,4 +2,19 @@ class ApplicationsController < ApplicationController
   def show 
     @application = Application.find(params[:id])
   end
+
+  def new
+
+  end
+
+  def create
+    application = Application.create(application_params)
+    redirect_to "/applications/#{application.id}"
+  end
+
+  private
+    def application_params
+      full_addr = "#{params[:addr]}, #{params[:city]}, #{params[:state]}, #{params[:zip]}"
+      params.permit(:name, :description).merge(address: full_addr, status: "In Progress")
+    end
 end

--- a/app/views/applications/new.html.erb
+++ b/app/views/applications/new.html.erb
@@ -1,0 +1,30 @@
+<h1>Start an Application</h1>
+
+<%= form_with url: "/applications", method: :post, data: { turbo: false } do |form| %>
+  <table>
+    <tr>
+      <td><%= form.label :name, "Name:" %></td>
+      <td><%= form.text_field :name %></td>
+    </tr>
+    <tr>
+      <td><%= form.label :addr, "Street Address:" %></td>
+      <td><%= form.text_field :addr %></td>
+    </tr>
+    <tr>
+      <td><%= form.label :city, "City:" %></td>
+      <td><%= form.text_field :city %></td>
+    </tr>
+    <tr>
+      <td><%= form.label :state, "State:" %></td>
+      <td><%= form.text_field :state %></td>
+    </tr>
+    <tr>
+      <td><%= form.label :zip, "Zip Code:" %></td>
+      <td><%= form.text_field :zip %></td>
+    </tr>
+  </table>
+  <br>
+  <%= form.label :description, "Why would you make a good home?:" %><br>
+  <%= form.text_area :description, size: "70x5" %><br>
+  <%= form.submit "Submit" %>
+<% end %>

--- a/app/views/pets/index.html.erb
+++ b/app/views/pets/index.html.erb
@@ -1,4 +1,5 @@
 <h1>All pets</h1>
+<h3><a href="/applications/new">Start an Application</a></h3>
 
 <%= form_with url: "/pets", method: :get, local: true do |f| %>
   <%= f.label :search %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -37,6 +37,8 @@ Rails.application.routes.draw do
   get "/veterinary_offices/:veterinary_office_id/veterinarians/new", to: "veterinarians#new"
   post "/veterinary_offices/:veterinary_office_id/veterinarians", to: "veterinarians#create"
 
+  post "/applications", to: "applications#create"
+  get "/applications/new", to: "applications#new"
   get "/applications/:id", to: "applications#show"
-  get "/applications/pets/:id", to: "pets#show"
+  get "/applications/pets/:id", to: "pets#show" # probably make this its own application_pets controller later on
 end

--- a/spec/features/applications/new_spec.rb
+++ b/spec/features/applications/new_spec.rb
@@ -1,0 +1,33 @@
+require 'rails_helper'
+
+RSpec.describe "the applications new page" do
+  it "has a form to fill in for a new application" do
+    visit "/applications/new"
+
+    expect(page).to have_field("name")
+    expect(page).to have_field("addr")
+    expect(page).to have_field("city")
+    expect(page).to have_field("state")
+    expect(page).to have_field("zip")
+    expect(page).to have_field("description")
+    expect(page).to have_button("submit")
+  end
+
+  it "creates a new application and redirects to the application show page when submitted" do
+    visit "/applications/new"
+
+    fill_in("name", with: "Tyler Blackmon")
+    fill_in("addr", with: "1234 Street Address")
+    fill_in("city", with: "Colorado Springs")
+    fill_in("state", with: "CO")
+    fill_in("zip", with: "80922")
+    fill_in("description", with: "I have a really good description so you should let me have a pet!")
+    click_button("Submit")
+
+    expect(page).to have_current_path("/applications/:id")
+    expect(page).to have_content("Tyler Blackmon")
+    expect(page).to have_content("1234 Street Address, Colorado Springs, CO, 80922")
+    expect(page).to have_content("I have a really good description so you should let me have a pet!")
+    expect(page).to have_content("In Progress")
+  end
+end

--- a/spec/features/applications/new_spec.rb
+++ b/spec/features/applications/new_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe "the applications new page" do
     expect(page).to have_field("state")
     expect(page).to have_field("zip")
     expect(page).to have_field("description")
-    expect(page).to have_button("submit")
+    expect(page).to have_button("Submit")
   end
 
   it "creates a new application and redirects to the application show page when submitted" do
@@ -24,7 +24,9 @@ RSpec.describe "the applications new page" do
     fill_in("description", with: "I have a really good description so you should let me have a pet!")
     click_button("Submit")
 
-    expect(page).to have_current_path("/applications/:id")
+    new_app = Application.all.first
+
+    expect(page).to have_current_path("/applications/#{new_app.id}")
     expect(page).to have_content("Tyler Blackmon")
     expect(page).to have_content("1234 Street Address, Colorado Springs, CO, 80922")
     expect(page).to have_content("I have a really good description so you should let me have a pet!")

--- a/spec/features/pets/index_spec.rb
+++ b/spec/features/pets/index_spec.rb
@@ -81,4 +81,14 @@ RSpec.describe "the pets index" do
     expect(page).to have_content(pet_2.name)
     expect(page).to_not have_content(pet_3.name)
   end
+
+  it "has a link to create a new application" do
+    visit "/pets"
+
+    expect(page).to have_link("Start an Application", href: "/application/new")
+
+    click_link("Start an Application")
+
+    expect(page).to have_current_path("/application/new")
+  end
 end

--- a/spec/features/pets/index_spec.rb
+++ b/spec/features/pets/index_spec.rb
@@ -85,10 +85,10 @@ RSpec.describe "the pets index" do
   it "has a link to create a new application" do
     visit "/pets"
 
-    expect(page).to have_link("Start an Application", href: "/application/new")
+    expect(page).to have_link("Start an Application", href: "/applications/new")
 
     click_link("Start an Application")
 
-    expect(page).to have_current_path("/application/new")
+    expect(page).to have_current_path("/applications/new")
   end
 end


### PR DESCRIPTION
- Link to /applications/new from /pets
- New routes for /applications/new
- New controller actions for #create
- Added a private #application_params method to the applications controller (check out the use of .merge here! found that while looking into how to pass hard-coded values through the permit method)
- New view for applications#new
- Tests for all of the above

I think that about covers it all... in short, you can now access a form to create a new application from the pets index. Submitting the form adds your app to the database, and redirects to the /applications/:id show page to view the app that was just created.